### PR TITLE
fix: move Redis URL environment check to function call and allow it to be passed as a parameter.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -16,8 +16,6 @@ import * as time from 'lib0/time'
 const logWorker = logging.createModuleLogger('@y/redis/api/worker')
 // const logApi = logging.createModuleLogger('@y/redis/api')
 
-export const redisUrl = env.ensureConf('ysr-redis')
-
 let ydocUpdateCallback = env.getConf('ydoc-update-callback')
 if (ydocUpdateCallback != null && ydocUpdateCallback.slice(-1) !== '/') {
   ydocUpdateCallback += '/'
@@ -103,7 +101,7 @@ export class Api {
    * @param {string=} prefix
    * @param {string=} url
    */
-  constructor (store, prefix = 'y', url = redisUrl) {
+  constructor (store, prefix = 'y', url) {
     this.store = store
     this.prefix = prefix
     this.consumername = random.uuidv4()
@@ -120,7 +118,7 @@ export class Api {
     this.redisWorkerGroupName = this.prefix + ':worker'
     this._destroyed = false
     this.redis = redis.createClient({
-      url,
+      url: url || env.ensureConf('ysr-redis'),
       // scripting: https://github.com/redis/node-redis/#lua-scripts
       scripts: {
         addMessage: redis.defineScript({

--- a/src/api.js
+++ b/src/api.js
@@ -101,7 +101,7 @@ export class Api {
    * @param {string=} prefix
    * @param {string=} url
    */
-  constructor (store, prefix = 'y', url) {
+  constructor (store, prefix = 'y', url = env.ensureConf('ysr-redis')) {
     this.store = store
     this.prefix = prefix
     this.consumername = random.uuidv4()
@@ -118,7 +118,7 @@ export class Api {
     this.redisWorkerGroupName = this.prefix + ':worker'
     this._destroyed = false
     this.redis = redis.createClient({
-      url: url || env.ensureConf('ysr-redis'),
+      url,
       // scripting: https://github.com/redis/node-redis/#lua-scripts
       scripts: {
         addMessage: redis.defineScript({

--- a/src/socketio.js
+++ b/src/socketio.js
@@ -35,10 +35,11 @@ class YSocketIOServer {
  * @param {import('./storage.js').AbstractStorage} store
  * @param {Object} conf
  * @param {string} [conf.redisPrefix]
+ * @param {string} [conf.redisUrl]
  * @param {import('./y-socket-io/y-socket-io.js').YSocketIOConfiguration['authenticate']} conf.authenticate
  */
-export const registerYSocketIOServer = async (io, store, conf) => {
-  const app = new YSocketIO(io, { authenticate: conf.authenticate })
-  const { client, subscriber } = await app.initialize(store, conf)
+export const registerYSocketIOServer = async (io, store, { authenticate, redisUrl, redisPrefix }) => {
+  const app = new YSocketIO(io, { authenticate })
+  const { client, subscriber } = await app.initialize(store, { redisUrl, redisPrefix })
   return new YSocketIOServer(app, client, subscriber)
 }

--- a/tests/api.tests.js
+++ b/tests/api.tests.js
@@ -3,6 +3,7 @@ import * as t from 'lib0/testing'
 import * as api from '../src/api.js'
 import * as encoding from 'lib0/encoding'
 import * as promise from 'lib0/promise'
+import * as env from 'lib0/environment'
 import * as redis from 'redis'
 import { prevClients, store } from './utils.js'
 
@@ -14,7 +15,7 @@ const redisPrefix = 'ytests'
 const createTestCase = async tc => {
   await promise.all(prevClients.map(c => c.destroy()))
   prevClients.length = 0
-  const redisClient = redis.createClient({ url: api.redisUrl })
+  const redisClient = redis.createClient({ url: env.ensureConf('ysr-redis') })
   await redisClient.connect()
   // flush existing content
   const keysToDelete = await redisClient.keys(redisPrefix + ':*')

--- a/tests/socketio.tests.js
+++ b/tests/socketio.tests.js
@@ -7,6 +7,7 @@ import * as array from 'lib0/array'
 import * as redis from 'redis'
 import * as time from 'lib0/time'
 import * as jwt from 'lib0/crypto/jwt'
+import * as env from 'lib0/environment'
 import * as utils from './utils.js'
 import { SocketIOProvider } from '../src/y-socket-io/client.js'
 
@@ -66,7 +67,7 @@ const createApiClient = async () => {
 const createTestCase = async (tc) => {
   await promise.all(utils.prevClients.map((c) => c.destroy()))
   utils.prevClients.length = 0
-  const redisClient = redis.createClient({ url: api.redisUrl })
+  const redisClient = redis.createClient({ url: env.ensureConf('ysr-redis') })
   await redisClient.connect()
   // flush existing content
   const keysToDelete = await redisClient.keys(utils.redisPrefix + ':*')


### PR DESCRIPTION
Having `env.ensureConf` at the top level will cause an error even if the Redis URL is passed as a parameter, so move it to the function call. If not passed, then fall back to the environment variable.