### PR TITLE
fix: init listeners before getDoc to solve server miss sync request problem

### DIFF
--- a/src/y-socket-io/y-socket-io.js
+++ b/src/y-socket-io/y-socket-io.js
@@ -153,6 +153,10 @@ export class YSocketIO {
       this.namespaceStreamMap.set(namespace, stream)
       this.streamNamespaceMap.set(stream, namespace)
 
+      this.initSyncListeners(socket)
+      this.initAwarenessListeners(socket)
+      this.initSocketListeners(socket)
+
       const doc = await this.client.getDoc(namespace, 'index')
 
       if (
@@ -162,12 +166,6 @@ export class YSocketIO {
         // need to renew subscription id and make sure that we catch the latest content.
         this.subscriber.ensureSubId(stream, doc.redisLastId)
       }
-
-      this.initSyncListeners(socket)
-      this.initAwarenessListeners(socket)
-
-      this.initSocketListeners(socket)
-
       this.startSynchronization(socket, doc)
     })
 


### PR DESCRIPTION
As title, the getDoc sometimes took too much time that cause server received `sync-step-1` event before listeners init.
And this cause frontend can not retrieve the full YDoc so I move listener initializers up to solve this problem.