### PR TITLE
fix: destroy `ydoc` after persisting to prevent memory leaks in worker

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -317,6 +317,8 @@ export class Api {
         } catch (e) {
           console.error(e)
         }
+        // destroy ydoc after persisting
+        ydoc.destroy()
       }
     }))
     return tasks


### PR DESCRIPTION
Clean up the `ydoc` instance after persisting since `getDoc` creates a new one each time in `consumeWorkerQueue`:

https://github.com/hackmdio/y-socketio-redis/blob/8a837eaada0b6b725bde26017b5c599aff312516/src/api.js#L227-L231

https://github.com/hackmdio/y-socketio-redis/blob/8a837eaada0b6b725bde26017b5c599aff312516/src/api.js#L293

ref: https://github.com/yjs/y-redis/pull/36
