### PR TITLE
Queue up sync step

### DIFF
--- a/src/y-socket-io/client.js
+++ b/src/y-socket-io/client.js
@@ -157,7 +157,7 @@ export class SocketIOProvider extends Observable {
 
     this.doc.on('update', this.onUpdateDoc)
 
-    this.socket.on('connect', () => this.onSocketConnection(resyncInterval))
+    this.socket.once('ready-for-sync', () => this.onSocketConnection(resyncInterval))
 
     this.socket.on('disconnect', (event) => this.onSocketDisconnection(event))
 

--- a/src/y-socket-io/y-socket-io.js
+++ b/src/y-socket-io/y-socket-io.js
@@ -171,6 +171,7 @@ export class YSocketIO {
         this.client.getDoc(namespace, 'index').then((doc) => {
           assert(socket.user)
           assert(this.subscriber)
+          socket.emit('ready-for-sync')
           if (
             api.isSmallerRedisId(doc.redisLastId, socket.user.initialRedisSubId)
           ) {

--- a/src/y-socket-io/y-socket-io.js
+++ b/src/y-socket-io/y-socket-io.js
@@ -91,6 +91,12 @@ export class YSocketIO {
   namespaceMap = new Map()
 
   /**
+   * @type {Promise<void>[]}
+   * @private
+   */
+  syncQueue = []
+
+  /**
    * YSocketIO constructor.
    * @constructor
    * @param {Server} io Server instance from Socket IO
@@ -157,16 +163,26 @@ export class YSocketIO {
       this.initAwarenessListeners(socket)
       this.initSocketListeners(socket)
 
-      const doc = await this.client.getDoc(namespace, 'index')
-
-      if (
-        api.isSmallerRedisId(doc.redisLastId, socket.user.initialRedisSubId)
-      ) {
-        // our subscription is newer than the content that we received from the api
-        // need to renew subscription id and make sure that we catch the latest content.
-        this.subscriber.ensureSubId(stream, doc.redisLastId)
-      }
-      this.startSynchronization(socket, doc)
+      /**
+       * @type {Promise<void>}
+       */
+      const task = new Promise((resolve) => {
+        assert(this.client)
+        this.client.getDoc(namespace, 'index').then((doc) => {
+          assert(socket.user)
+          assert(this.subscriber)
+          if (
+            api.isSmallerRedisId(doc.redisLastId, socket.user.initialRedisSubId)
+          ) {
+            // our subscription is newer than the content that we received from the api
+            // need to renew subscription id and make sure that we catch the latest content.
+            this.subscriber.ensureSubId(stream, doc.redisLastId)
+          }
+          this.startSynchronization(socket, doc)
+          resolve()
+        })
+      })
+      this.queueUpSyncTask(task)
     })
 
     return { client, subscriber }
@@ -334,6 +350,25 @@ export class YSocketIO {
       if (msg.length === 0) continue
       nsp.emit('awareness-update', msg)
     }
+  }
+
+  /**
+   * @private
+   * @param {Promise<void>} task
+   */
+  queueUpSyncTask (task) {
+    const len = this.syncQueue.push(task)
+    if (len === 1) this.consumeSyncQueue()
+  }
+
+  /**
+   * @private
+   */
+  async consumeSyncQueue () {
+    if (this.syncQueue.length === 0) return
+    const task = this.syncQueue.shift()
+    await task
+    this.consumeSyncQueue()
   }
 
   /**


### PR DESCRIPTION
把原本 namespace on connection 時的 `getDoc` 包成 promise 放進 `syncQueue` 裡面
`syncQueue` 一次消化完一個 promise 才會繼續執行下一個

同時 client 本來 on connection 會自動 emit `sync-step-1`
現在也推遲到 server ready 了才會開始 sync