### PR TITLE
fix/prevent trimming stream after removed

### DIFF
--- a/src/y-socket-io/y-socket-io.js
+++ b/src/y-socket-io/y-socket-io.js
@@ -536,7 +536,17 @@ export class YSocketIO {
           } else {
             await this.client.store.persistDoc(namespace, 'index', doc)
           }
-          await this.client.trimRoomStream(namespace, 'index')
+
+          /**
+           * there's a possibility where the namespace is deleted after the
+           * persist promise resolved, so we have to check if the room still
+           * exist.
+           * @see cleanupNamespace
+           * @see cleanupNamespaceImpl
+           */
+          if (this.namespaceMap.has(namespace)) {
+            await this.client.trimRoomStream(namespace, 'index')
+          }
         } catch (e) {
           console.error(e)
         } finally {


### PR DESCRIPTION
There's a possibility that the stream would be deleted before `xTrim` is called. When persisting in worker, a promise is created and would resolve once the worker is done processing persisting.

Where this line would be called:
https://github.com/hackmdio/y-socketio-redis/blob/e85b438bec4157b21c08fcf1cc4d8c5cd83139ff/src/y-socket-io/y-socket-io.js?plain=1#L680

Before this line:
https://github.com/hackmdio/y-socketio-redis/blob/e85b438bec4157b21c08fcf1cc4d8c5cd83139ff/src/y-socket-io/y-socket-io.js?plain=1#L539

Due to here also waiting on the same promise:
https://github.com/hackmdio/y-socketio-redis/blob/e85b438bec4157b21c08fcf1cc4d8c5cd83139ff/src/y-socket-io/y-socket-io.js?plain=1#L659

In this PR, we check if the namespace still exists before calling on the trim function. The namespace is deleted here:
https://github.com/hackmdio/y-socketio-redis/blob/e85b438bec4157b21c08fcf1cc4d8c5cd83139ff/src/y-socket-io/y-socket-io.js?plain=1#L678
Just before deleting the stream, so we can assume the stream still exists in Redis if the namespace is still alive.