### PR TITLE
fix/check for stream existence before trimming

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -300,6 +300,8 @@ export class Api {
     const roomName = computeRedisRoomStreamName(room, docid, this.prefix)
     const redisLastId = await this.getRedisLastId(room, docid)
     const lastId = number.parseInt(redisLastId.split('-')[0])
+    const roomExists = await this.redis.exists(roomName)
+    if (!roomExists) return
     if (remove) {
       await this.redis.del(roomName)
     } else {


### PR DESCRIPTION
In a distributive architecture, the stream could be deleted from another instance without the current running instance noticing. It's not a problem since data would not be lost (the stream is only deleted after data persistence), but we should still try to handle this error case.

In this PR, we check if the stream exists before trying to do any operation on it to avoid this race condition from happening.