### PR TITLE
fix/use latest doc on persist & correct queueing

### DIFF
--- a/src/y-socket-io/y-socket-io.js
+++ b/src/y-socket-io/y-socket-io.js
@@ -129,12 +129,6 @@ export class YSocketIO {
    */
   debouncedPersistMap = new Map()
   /**
-   * @type {Map<string, Y.Doc>}
-   * @private
-   * @readonly
-   */
-  debouncedPersistDocMap = new Map()
-  /**
    * @type {Map<string, number>}
    * @private
    * @readonly
@@ -373,8 +367,7 @@ export class YSocketIO {
         const nsp = this.namespaceMap.get(ns)
         if (nsp?.sockets.size === 0 && stream) {
           this.cleanupNamespace(ns, stream, DEFAULT_CLEAR_TIMEOUT)
-          const doc = this.namespaceDocMap.get(ns)
-          if (doc) this.debouncedPersist(ns, doc.ydoc, true)
+          if (this.namespaceDocMap.has(ns)) this.debouncedPersist(ns, true)
         }
       }
     })
@@ -492,7 +485,7 @@ export class YSocketIO {
     const shouldPersist = now - lastPersistCalledAt > MAX_PERSIST_INTERVAL
     if (changed || shouldPersist || nsp.sockets.size === 0) {
       this.namespacePersistentMap.set(namespace, now)
-      this.debouncedPersist(namespace, doc.ydoc, nsp.sockets.size === 0)
+      this.debouncedPersist(namespace, nsp.sockets.size === 0)
     }
     this.namespaceDocMap.get(namespace)?.ydoc.destroy()
     this.namespaceDocMap.set(namespace, doc)
@@ -500,11 +493,9 @@ export class YSocketIO {
 
   /**
    * @param {string} namespace
-   * @param {Y.Doc} doc
    * @param {boolean=} immediate
    */
-  debouncedPersist (namespace, doc, immediate = false) {
-    this.debouncedPersistDocMap.set(namespace, doc)
+  debouncedPersist (namespace, immediate = false) {
     if (this.debouncedPersistMap.has(namespace)) {
       if (!immediate) return
       clearTimeout(this.debouncedPersistMap.get(namespace) || undefined)
@@ -514,9 +505,17 @@ export class YSocketIO {
       : PERSIST_INTERVAL + (Math.random() - 0.5) * PERSIST_INTERVAL
     const timeout = setTimeout(
       async () => {
+        // wait for previous persisting operation if exists
+        const prev = this.awaitingPersistMap.get(namespace)
+        if (prev?.promise) await prev.promise
+        // delete persist entry to allow queueing next persisting operation
+        // we can delete it here because the following until awaiting persist
+        // are all synchronize operations
+        this.debouncedPersistMap.delete(namespace)
+
         try {
           assert(this.client)
-          const doc = this.debouncedPersistDocMap.get(namespace)
+          const doc = this.namespaceDocMap.get(namespace)?.ydoc
           logSocketIO(`trying to persist ${namespace}`)
           if (!doc) return
           if (this.client.persistWorker) {
@@ -534,15 +533,14 @@ export class YSocketIO {
             })
             await promise
           } else {
-            await this.client.store.persistDoc(namespace, 'index', doc)
+            const promise = this.client.store.persistDoc(namespace, 'index', doc)
+            this.awaitingPersistMap.set(namespace, { promise, resolve: () => {} })
+            await promise
           }
 
           await this.client.trimRoomStream(namespace, 'index')
         } catch (e) {
           console.error(e)
-        } finally {
-          this.debouncedPersistDocMap.delete(namespace)
-          this.debouncedPersistMap.delete(namespace)
         }
       },
       timeoutInterval


### PR DESCRIPTION
This PR fixes two potential issues:
1. Remove the need for `debouncedPersistDocMap`, which could lead to data missing if `debouncedPersist` is called when persisting. (Detail explained below)
2. Allow queueing the next persist operation immediately after the current persist request fires. This ensures that every persistent call eventually results in a persist.


The current flow looks like this:
<img src="https://github.com/user-attachments/assets/ec0dc363-ad14-4c47-a208-5def448bcb4d" height="400px">
If the stream is scheduled for persistence, another call to `debouncedPersist` will do nothing but update the doc for persistence.

But the updated doc would be dropped if the call to `debouncedPersist` is during the persistence stage:
<img src="https://github.com/user-attachments/assets/da1e9ee2-0040-41e0-afc5-e0fe3e81436b" height="400px">
This is because the doc to persist is retrieved at the start of the persistence stage, but the stream key is still in the queue. Calling `debouncedPersist` now would only update `debouncedPersistDocMap` without scheduling a new persistence operation. The newly updated doc will be cleared after the previous persistence without being saved.

In this PR, I restructured the queueing and persisting algorithm to the following:
<img src="https://github.com/user-attachments/assets/2b6ec83a-0dc1-4944-800e-6e9cb8204482" height="400px">
Where when persisting, we always use the latest doc in the cache. Once the doc to persist is retrieved, we dequeue the current stream key immediately to allow the queueing of new persistence operations.
