### PR TITLE
fix/incorrect persistence leader aquire check

### DIFF
--- a/src/y-socket-io/y-socket-io.js
+++ b/src/y-socket-io/y-socket-io.js
@@ -859,10 +859,13 @@ export class YSocketIO {
     assert(this.client)
     const redis = this.client.redis
     const key = this.getLeaderKeyOf(namespace)
-    const ok = await redis.set(key, this.serverId, {
+    await redis.set(key, this.serverId, {
       NX: true,
       PX: PERSIST_LEADER_HEARTBEAT_INTERVAL
     })
+
+    const curLeader = await redis.get(key)
+    const ok = curLeader === this.serverId
     if (!ok) return false
 
     this.persistentLeaderOf.add(namespace)

--- a/src/y-socket-io/y-socket-io.js
+++ b/src/y-socket-io/y-socket-io.js
@@ -859,13 +859,13 @@ export class YSocketIO {
     assert(this.client)
     const redis = this.client.redis
     const key = this.getLeaderKeyOf(namespace)
-    await redis.set(key, this.serverId, {
+    const prevVal = await redis.set(key, this.serverId, {
       NX: true,
-      PX: PERSIST_LEADER_HEARTBEAT_INTERVAL
+      PX: PERSIST_LEADER_HEARTBEAT_INTERVAL,
+      GET: true
     })
 
-    const curLeader = await redis.get(key)
-    const ok = curLeader === this.serverId
+    const ok = prevVal === this.serverId || prevVal === null
     if (!ok) return false
 
     this.persistentLeaderOf.add(namespace)


### PR DESCRIPTION
`set` returns false if the current server is already a leader. In this PR, we `get` the current leader immediately after `set` to check if the current server is the leader.